### PR TITLE
Fix stale homepage catalog discovered by Playwright smoke

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -1,6 +1,8 @@
 ---
 format: html
 profile: english
+execute:
+  freeze: false
 ---
 
 # FADS Open Science Hub 🐟💾


### PR DESCRIPTION
## Summary
Playwright smoke checks uncovered a real homepage regression:

- The article catalog on `index.html` was stale (15 rows instead of current 31 routes).
- Search/filter actions (e.g., `fsar`, `How-to`) produced zero results on deployed site.

Root cause: homepage data table was generated via R but `freeze: auto` reused stale execution results for `index.qmd`.

## Fix
- Set page-level execution override in `index.qmd`:
  - `execute: { freeze: false }`

This keeps homepage dynamic sections (latest updates + article catalog) current at render/publish time.

## Validation
- Local Playwright smoke against rendered `_site` now passes:
  - homepage interactions
  - all qmd-derived routes return HTTP 200
  - legacy aliases resolve to canonical pages
  - no page errors on critical pages
